### PR TITLE
paxctl.spec wrong archive type fix

### DIFF
--- a/paxctl/paxctl.spec
+++ b/paxctl/paxctl.spec
@@ -7,7 +7,7 @@ License: GPLv2
 BuildArch: x86_64
 
 URL: https://pax.grsecurity.net
-Source: https://pax.grsecurity.net/paxctl-0.9.tar.xz
+Source: https://pax.grsecurity.net/paxctl-0.9.tar.gz
 
 %description
   This is paxctl for controlling PaX flags on a per binary basis. PaX


### PR DESCRIPTION
You can't build paxctl as described without that fix